### PR TITLE
fix(--debug) Error: Cannot find module

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -421,7 +421,7 @@ function serve(isDev, specRunner) {
         log('Running node-inspector. Browse to http://localhost:8080/debug?port=5858');
         exec = require('child_process').exec;
         exec('node-inspector');
-        nodeOptions.nodeArgs = [debug + '=5858'];
+        nodeOptions.nodeArgs = ['--debug=5858'];
     }
 
     return $.nodemon(nodeOptions)


### PR DESCRIPTION
When running the command
```
gulp serve-dev --debug
```

Its crashing out in the console with
```
[BS] [debug] Resolved www.google.com, setting online: true
...
Error: Cannot find module '/Users/j.../gulp/gulp-patterns/true=5858'
```

I think the debug on line 424 is evaluating to 'true'
```
nodeOptions.nodeArgs = [debug + '=5858'];
```

Awesome gulp code by the way, learning alot of new stuff!

Many Thanks

Jonny
