### PR TITLE
use .once() instead of .one()

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -469,7 +469,7 @@ function serve(isDev, specRunner) {
                 browserSync.reload({stream: false});
             }, config.browserReloadDelay);
         })
-        .on('start', function () {
+        .once('start', function () {
             log('*** nodemon started');
             startBrowserSync(isDev, specRunner);
         })


### PR DESCRIPTION
prevent browserSync trying to start the same instance when the server is restarted after changing server files that are being watched by nodemon.

``` sh
[error] You tried to start Browsersync twice! To create multiple instances, use browserSync.create().init()
```
