### PR TITLE
fix typo in .tmp dir

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -49,7 +49,7 @@ switch (environment) {
         console.log('** DEV **');
         app.use(express.static('./src/client/'));
         app.use(express.static('./'));
-        app.use(express.static('./tmp'));
+        app.use(express.static('./.tmp'));
         // All the assets are served at this point.
         // Any invalid calls for templateUrls are under app/* and should return 404
         app.use('/app/*', function(req, res, next) {


### PR DESCRIPTION
isn't this `./.tmp` with a dot?

like here https://github.com/johnpapa/gulp-patterns/blob/master/gulp.config.js#L8 ?