### PR TITLE
prevent race conditions in bsReload

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ var $ = require('gulp-load-plugins')({lazy: true});
 var colors = $.util.colors;
 var envenv = $.util.env;
 var port = process.env.PORT || config.defaultPort;
+var syncing = false;
 
 /**
  * yargs variables can be passed in to alter the behavior, when present.
@@ -370,7 +371,16 @@ gulp.task('bump', function() {
 /**
  * Optimize the code and re-load browserSync
  */
-gulp.task('browserSyncReload', ['optimize'], browserSync.reload);
+gulp.task('browserSyncReload', function() {
+    if (syncing) {
+        return;
+    }
+    syncing = true;
+    gulp.start('optimize', function() {
+        browserSync.reload();
+        syncing = false;
+    });
+});
 
 ////////////////
 


### PR DESCRIPTION
between wiredep, less, and js, was getting race conditions because 'serve-build' was kicking off optimize indiscriminately.  Added 'syncing' flag to prevent optimize from getting called recursively.