### PR TITLE
wiredep task error fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -135,7 +135,7 @@ gulp.task('wiredep', function() {
     return gulp
         .src(config.index)
         .pipe(wiredep(options))
-        .pipe(inject(js, '', config.jsOrder))
+        .pipe(inject(gulp.src(config.js), '', config.jsOrder))
         .pipe(gulp.dest(config.client));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -135,7 +135,7 @@ gulp.task('wiredep', function() {
     return gulp
         .src(config.index)
         .pipe(wiredep(options))
-        .pipe(inject(gulp.src(config.js), '', config.jsOrder))
+        .pipe(inject(gulp.src(js), '', config.jsOrder))
         .pipe(gulp.dest(config.client));
 });
 


### PR DESCRIPTION
This is a fix for the newer versions of gulp inject that expects a stream instead of src string.
Error-
10:21:17] 'wiredep' errored after
[10:21:17] Error in plugin 'gulp-inject'
Message:
    passing target file as a string is deprecated! Pass a vinyl file stream (i.e. use `gulp.src`)!

